### PR TITLE
Add nng 2.x support and send/recv functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
+.vscode
 node_modules
 npm-debug.log
 package-*

--- a/binding.cc
+++ b/binding.cc
@@ -21,6 +21,8 @@
 */
 
 #include <nng/nng.h>
+
+#if !defined(NNG_MAJOR_VERSION) || (NNG_MAJOR_VERSION < 2)
 #include <nng/protocol/bus0/bus.h>
 #include <nng/protocol/pair0/pair.h>
 #include <nng/protocol/pair1/pair.h>
@@ -32,10 +34,20 @@
 #include <nng/protocol/survey0/respond.h>
 #include <nng/protocol/pubsub0/sub.h>
 #include <nng/protocol/survey0/survey.h>
+#endif
 
 #include "timer.h"
 #include "nan.h"
 #include "ref.h"
+#include <cstring>
+
+#if defined(NNG_MAJOR_VERSION) && (NNG_MAJOR_VERSION >= 2)
+#define NODENNG_CLOSE(s) nng_socket_close(s)
+#define NODENNG_STRERROR(e) nng_strerror(static_cast<nng_err>(e))
+#else
+#define NODENNG_CLOSE(s) nng_close(s)
+#define NODENNG_STRERROR(e) nng_strerror(e)
+#endif
 
 using v8::FunctionTemplate;
 using v8::Function;
@@ -56,118 +68,31 @@ using Nan::Set;
 using Nan::New;
 using Nan::To;
 
-NAN_METHOD(bus_open) {
-  size_t sz = sizeof (nng_socket);
-  nng_socket s;
-  nng_bus0_open(&s); //nng_bus0_open_raw
-
-  Local<Object> sock = NewBuffer(sz).ToLocalChecked();
-  memcpy(node::Buffer::Data(sock), &s, sz);
-  info.GetReturnValue().Set(sock);
+#define DEFINE_OPENER(name, func) \
+NAN_METHOD(name) { \
+  size_t sz = sizeof(nng_socket); \
+  nng_socket s = {}; \
+  int rv = func(&s); \
+  if (rv != 0) { \
+    Nan::ThrowError(NODENNG_STRERROR(rv)); \
+    return; \
+  } \
+  Local<Object> sock = NewBuffer(sz).ToLocalChecked(); \
+  memcpy(node::Buffer::Data(sock), &s, sz); \
+  info.GetReturnValue().Set(sock); \
 }
 
-NAN_METHOD(pair0_open) {
-  size_t sz = sizeof (nng_socket);
-  nng_socket s;
-  nng_pair0_open(&s); //nng_pair0_open_raw
-
-  Local<Object> sock = NewBuffer(sz).ToLocalChecked();
-  memcpy(node::Buffer::Data(sock), &s, sz);
-  info.GetReturnValue().Set(sock);
-}
-
-//NNG_OPT_PAIR1_POLY
-//NNG_OPT_MAXTTL
-NAN_METHOD(pair1_open) {
-  size_t sz = sizeof (nng_socket);
-  nng_socket s;
-  nng_pair1_open(&s); //nng_pair1_open_raw
-
-  Local<Object> sock = NewBuffer(sz).ToLocalChecked();
-  memcpy(node::Buffer::Data(sock), &s, sz);
-  info.GetReturnValue().Set(sock);
-}
-
-NAN_METHOD(pub_open) {
-  size_t sz = sizeof (nng_socket);
-  nng_socket s;
-  nng_pub0_open(&s); //nng_pub0_open_raw
-
-  Local<Object> sock = NewBuffer(sz).ToLocalChecked();
-  memcpy(node::Buffer::Data(sock), &s, sz);
-  info.GetReturnValue().Set(sock);
-}
-
-NAN_METHOD(pull_open) {
-  size_t sz = sizeof (nng_socket);
-  nng_socket s;
-  nng_pull0_open(&s); //nng_pull0_open_raw
-
-  Local<Object> sock = NewBuffer(sz).ToLocalChecked();
-  memcpy(node::Buffer::Data(sock), &s, sz);
-  info.GetReturnValue().Set(sock);
-}
-
-NAN_METHOD(push_open) {
-  size_t sz = sizeof (nng_socket);
-  nng_socket s;
-  nng_push0_open(&s); //nng_push0_open_raw
-
-  Local<Object> sock = NewBuffer(sz).ToLocalChecked();
-  memcpy(node::Buffer::Data(sock), &s, sz);
-  info.GetReturnValue().Set(sock);
-}
-
-NAN_METHOD(rep_open) {
-  size_t sz = sizeof (nng_socket);
-  nng_socket s;
-  nng_rep0_open(&s); //nng_rep0_open_raw
-
-  Local<Object> sock = NewBuffer(sz).ToLocalChecked();
-  memcpy(node::Buffer::Data(sock), &s, sz);
-  info.GetReturnValue().Set(sock);
-}
-
-NAN_METHOD(req_open) {
-  size_t sz = sizeof (nng_socket);
-  nng_socket s;
-  nng_req0_open(&s); //nng_req0_open_raw
-
-  Local<Object> sock = NewBuffer(sz).ToLocalChecked();
-  memcpy(node::Buffer::Data(sock), &s, sz);
-  info.GetReturnValue().Set(sock);
-}
-
-NAN_METHOD(respondent_open) {
-  size_t sz = sizeof (nng_socket);
-  nng_socket s;
-  nng_respondent0_open(&s); //nng_respondent0_open_raw
-
-  Local<Object> sock = NewBuffer(sz).ToLocalChecked();
-  memcpy(node::Buffer::Data(sock), &s, sz);
-  info.GetReturnValue().Set(sock);
-}
-
-NAN_METHOD(sub_open) {
-  size_t sz = sizeof (nng_socket);
-  nng_socket s;
-  nng_sub0_open(&s); //nng_sub0_open_raw
-
-  Local<Object> sock = NewBuffer(sz).ToLocalChecked();
-  memcpy(node::Buffer::Data(sock), &s, sz);
-  info.GetReturnValue().Set(sock);
-}
-
-NAN_METHOD(surveyor_open) {
-  size_t sz = sizeof (nng_socket);
-  nng_socket s;
-  nng_surveyor0_open(&s); // nng_surveyor0_open_raw
-
-  Local<Object> sock = NewBuffer(sz).ToLocalChecked();
-  memcpy(node::Buffer::Data(sock), &s, sz);
-  info.GetReturnValue().Set(sock);
-}
-
+DEFINE_OPENER(bus_open, nng_bus0_open)
+DEFINE_OPENER(pair0_open, nng_pair0_open)
+DEFINE_OPENER(pair1_open, nng_pair1_open)
+DEFINE_OPENER(pub_open, nng_pub0_open)
+DEFINE_OPENER(sub_open, nng_sub0_open)
+DEFINE_OPENER(pull_open, nng_pull0_open)
+DEFINE_OPENER(push_open, nng_push0_open)
+DEFINE_OPENER(req_open, nng_req0_open)
+DEFINE_OPENER(rep_open, nng_rep0_open)
+DEFINE_OPENER(surveyor_open, nng_surveyor0_open)
+DEFINE_OPENER(respondent_open, nng_respondent0_open)
 
 /**
  * nanomsg.github.io/nng/man/tip/nng_close.3
@@ -179,16 +104,26 @@ NAN_METHOD(surveyor_open) {
  */
 
 NAN_METHOD(close) {
-  int clsd = nng_close(*UnwrapPointer<nng_socket*>(info[0]));
+  if (info.Length() < 1) {
+    Nan::ThrowTypeError("Socket required");
+    return;
+  }
+
+  int clsd = NODENNG_CLOSE(*UnwrapPointer<nng_socket*>(info[0]));
   if (clsd == 0) {
     info.GetReturnValue().Set(New<Number>(clsd));
   } else {
-    info.GetReturnValue().Set(New<String>(nng_strerror(clsd)).ToLocalChecked());
+    info.GetReturnValue().Set(New<String>(NODENNG_STRERROR(clsd)).ToLocalChecked());
   }
 }
 
 //int nng_listen(nng_socket s, const char *url, nng_listener *lp, int flags);
 NAN_METHOD(listen) {
+  if (info.Length() < 2) {
+    Nan::ThrowTypeError("Socket and URL required");
+    return;
+  }
+
   Utf8String url(info[1]);
 
   // do we want to return the nng_listener??
@@ -202,12 +137,17 @@ NAN_METHOD(listen) {
   } else {
     info
       .GetReturnValue()
-      .Set(New<String>(nng_strerror(l)).ToLocalChecked());
+      .Set(New<String>(NODENNG_STRERROR(l)).ToLocalChecked());
   }
 }
 
 //int nng_dial(nng_socket s, const char *url, nng_dialer *dp, int flags);
 NAN_METHOD(dial) {
+  if (info.Length() < 2) {
+    Nan::ThrowTypeError("Socket and URL required");
+    return;
+  }
+
   Utf8String url(info[1]);
 
   // do we want to return the nng_dialer?
@@ -217,7 +157,7 @@ NAN_METHOD(dial) {
   if (d == 0) {
     info.GetReturnValue().Set(New<Number>(d)); // <-- good spot for nng_dialer
   } else {
-    info.GetReturnValue().Set(New<String>(nng_strerror(d)).ToLocalChecked());
+    info.GetReturnValue().Set(New<String>(NODENNG_STRERROR(d)).ToLocalChecked());
   }
 }
 
@@ -231,19 +171,35 @@ NAN_METHOD(dial) {
  */
 
 NAN_METHOD(setopt) {
-  Utf8String opt(info[1]);
-
-  char *val = NULL;
-  if (info[2]->IsString()) {
-    Utf8String val(info[1]);
+  if (info.Length() < 3) {
+    Nan::ThrowTypeError("Socket, option, and value required");
+    return;
   }
 
-  int sopt = nng_setopt(*UnwrapPointer<nng_socket*>(info[0]), *opt, val, 0);
+  Utf8String opt(info[1]);
+  Utf8String val(info[2]);
+  int sopt;
+
+#if defined(NNG_MAJOR_VERSION) && (NNG_MAJOR_VERSION >= 2)
+  sopt = NNG_ENOTSUP;
+  if (strcmp(*opt, "sub:subscribe") == 0) {
+    sopt = nng_sub0_socket_subscribe(
+      *UnwrapPointer<nng_socket*>(info[0]),
+      *val,
+      strlen(*val));
+  }
+#else
+  sopt = nng_setopt(
+    *UnwrapPointer<nng_socket*>(info[0]),
+    *opt,
+    *val,
+    strlen(*val));
+#endif
 
   if (sopt == 0) {
     info.GetReturnValue().Set(New<Number>(sopt));
   } else {
-    info.GetReturnValue().Set(New<String>(nng_strerror(sopt)).ToLocalChecked());
+    info.GetReturnValue().Set(New<String>(NODENNG_STRERROR(sopt)).ToLocalChecked());
   }
 }
 
@@ -264,6 +220,14 @@ NAN_METHOD(test){
 
 NAN_MODULE_INIT(Init) {
   HandleScope scope;
+
+#if defined(NNG_MAJOR_VERSION) && (NNG_MAJOR_VERSION >= 2)
+  nng_err init_rv = nng_init(NULL);
+  if (init_rv != 0) {
+    Nan::ThrowError(NODENNG_STRERROR(init_rv));
+    return;
+  }
+#endif
 
   /* open */
   EXPORT_METHOD(target, bus_open);
@@ -292,6 +256,21 @@ NAN_MODULE_INIT(Init) {
   EXPORT_METHOD(target, test);
 
   /* symbols */
+#if defined(NNG_OPT_SUB_SUBSCRIBE)
   EXPORT_SYMBOL(target, NNG_OPT_SUB_SUBSCRIBE);
+#else
+  Set(
+    target,
+    New("NNG_OPT_SUB_SUBSCRIBE").ToLocalChecked(),
+    New("sub:subscribe").ToLocalChecked());
+#endif
+#if defined(NNG_OPT_SUB_UNSUBSCRIBE)
+  EXPORT_SYMBOL(target, NNG_OPT_SUB_UNSUBSCRIBE);
+#else
+  Set(
+    target,
+    New("NNG_OPT_SUB_UNSUBSCRIBE").ToLocalChecked(),
+    New("sub:unsubscribe").ToLocalChecked());
+#endif
 }
 NODE_MODULE(nodenng, Init)

--- a/binding.cc
+++ b/binding.cc
@@ -39,7 +39,6 @@
 #include "timer.h"
 #include "nan.h"
 #include "ref.h"
-#include <cstring>
 
 #if defined(NNG_MAJOR_VERSION) && (NNG_MAJOR_VERSION >= 2)
 #define NODENNG_CLOSE(s) nng_socket_close(s)

--- a/binding.cc
+++ b/binding.cc
@@ -203,6 +203,83 @@ NAN_METHOD(setopt) {
   }
 }
 
+NAN_METHOD(send_msg) {
+  if (info.Length() < 2) {
+    Nan::ThrowTypeError("Socket and message required");
+    return;
+  }
+
+  nng_socket *sock = UnwrapPointer<nng_socket*>(info[0]);
+
+  if (!node::Buffer::HasInstance(info[1])) {
+    Nan::ThrowTypeError("Argument must be a Buffer");
+    return;
+  }
+
+  char *data = node::Buffer::Data(info[1]);
+  size_t len = node::Buffer::Length(info[1]);
+
+  int rv = nng_send(*sock, data, len, 0);
+
+  if (rv == 0) {
+    info.GetReturnValue().Set(New<Number>(rv));
+  } else {
+    info.GetReturnValue().Set(
+      New<String>(NODENNG_STRERROR(rv)).ToLocalChecked()
+    );
+  }
+}
+
+NAN_METHOD(recv_msg) {
+  if (info.Length() < 1) {
+    Nan::ThrowTypeError("Socket required");
+    return;
+  }
+
+  nng_socket *sock = UnwrapPointer<nng_socket*>(info[0]);
+
+#if defined(NNG_MAJOR_VERSION) && (NNG_MAJOR_VERSION >= 2)
+
+  nng_msg *msg = NULL;
+  int rv = nng_recvmsg(*sock, &msg, 0);
+
+  if (rv != 0) {
+    info.GetReturnValue().Set(
+      New<String>(NODENNG_STRERROR(rv)).ToLocalChecked()
+    );
+    return;
+  }
+
+  void *buf = nng_msg_body(msg);
+  size_t size = nng_msg_len(msg);
+
+  Local<Object> out =
+    Nan::CopyBuffer((char*)buf, size).ToLocalChecked();
+
+  nng_msg_free(msg);
+#else
+
+  void *buf = NULL;
+  size_t size;
+
+  int rv = nng_recv(*sock, &buf, &size, NNG_FLAG_ALLOC);
+
+  if (rv != 0) {
+    info.GetReturnValue().Set(
+      New<String>(NODENNG_STRERROR(rv)).ToLocalChecked()
+    );
+    return;
+  }
+
+  Local<Object> out =
+    Nan::CopyBuffer((char*)buf, size).ToLocalChecked();
+
+  nng_free(buf, size);
+#endif
+
+  info.GetReturnValue().Set(out);
+}
+
 NAN_METHOD(test){
   printf("sleeping for 5\n");
   reqsleep(5);
@@ -251,6 +328,10 @@ NAN_MODULE_INIT(Init) {
 
   /* setopt */
   EXPORT_METHOD(target, setopt);
+
+  /* send and recv */
+  EXPORT_METHOD(target, send_msg);
+  EXPORT_METHOD(target, recv_msg);
 
   /* debug */
   EXPORT_METHOD(target, test);

--- a/compile
+++ b/compile
@@ -1,7 +1,10 @@
 #!/bin/bash
+# Fallback to nng branch "stable", if not set specifically.
+NNG_BRANCH=${NNG_BRANCH:-stable}
+
 if [ ! -d nng ]; then
   rm -rf deps nng build && mkdir deps
-  git clone --depth 1 https://github.com/nanomsg/nng && cd nng
+  git clone --depth 1 --branch "$NNG_BRANCH" https://github.com/nanomsg/nng && cd nng
 else
   cd nng
   git pull
@@ -16,5 +19,11 @@ then
 fi
 
 mkdir -p build && cd build
-cmake -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_MESSAGE=NEVER -DCMAKE_INSTALL_PREFIX=$(pwd)/../../deps .. -DNNG_TESTS=OFF -DNNG_TOOLS=OFF -DNNG_ENABLE_NNGCAT=OFF -DNNG_ENABLE_COVERAGE=OFF
+cmake -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_MESSAGE=NEVER -DCMAKE_INSTALL_PREFIX=$(pwd)/../../deps .. \
+      -DNNG_TESTS=OFF \
+      -DNNG_TOOLS=OFF \
+      -DNNG_ENABLE_NNGCAT=OFF \
+      -DNNG_ENABLE_COVERAGE=OFF \
+      -DBUILD_SHARED_LIBS=OFF
+
 make MACOSX_DEPLOYMENT_TARGET=10.15 all install

--- a/test/index.js
+++ b/test/index.js
@@ -35,8 +35,8 @@ require ('tape')(`${bar} nng testsuite summary ${bar}`, function tests (t){
   test('listen')
   test('dial')
   test('setopt')
-
-
+  test('send_msg')
+  test('recv_msg')
 
 
 

--- a/test/recv_msg.js
+++ b/test/recv_msg.js
@@ -1,0 +1,90 @@
+/*
+
+  Copyright (c) 2019 Shiddeshwaran S <shiddeshwaran@gmail.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom
+  the Software is furnished to do so, subject to the following conditions:
+  The above copyright notice and this permission notice shall be included
+  in all copies or substantial portions of the Software.
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+
+*/
+
+module.exports  = recv_msg
+
+function recv_msg(t){
+  t.plan(9)
+
+  const str = 'recv succeeds for'
+  const url = 'tcp://127.0.0.1'
+  const {
+    bus_open,
+    pair0_open,
+    pair1_open,
+    pull_open,
+    rep_open,
+    req_open,
+    respondent_open,
+    sub_open,
+    surveyor_open,
+    dial,
+    recv_msg,
+  } = require('..')
+
+  const message = Buffer.from('hello from sender');
+
+  // bus
+  const bus = bus_open()
+  dial(bus, `${url}:7777`)
+  t.is(recv_msg(bus, message), 0, `${str} bus`)
+
+  // pair0
+  const pair0 = pair0_open()
+  dial(pair0, `${url}:7778`)
+  t.is(recv_msg(pair0, message), 0, `${str} pair0`)
+
+  // pair1
+  const pair1 = pair1_open()
+  dial(pair1, `${url}:7779`)
+  t.is(recv_msg(pair1, message), 0, `${str} pair1`)
+
+  // pull
+  const pull = pull_open()
+  dial(pull, `${url}:7781`)
+  t.is(recv_msg(pull, message), 0, `${str} pull`)
+
+  // rep
+  const rep = rep_open()
+  dial(rep, `${url}:7783`)
+  t.is(recv_msg(rep, message), 0, `${str} rep`)
+
+  // req
+  const req = req_open()
+  dial(req, `${url}:7784`)
+  t.is(recv_msg(req, message), 0, `${str} req`)
+
+  // respondent
+  const respondent = respondent_open()
+  dial(respondent, `${url}:7785`)
+  t.is(recv_msg(respondent, message), 0, `${str} respondent`)
+
+  // sub
+  const sub = sub_open()
+  dial(sub, `${url}:7786`)
+  t.is(recv_msg(sub, message), 0, `${str} sub`)
+
+  // surveyor
+  const surveyor = surveyor_open()
+  dial(surveyor, `${url}:7787`)
+  t.is(recv_msg(surveyor, message), 0, `${str} surveyor`)
+}

--- a/test/recv_msg.js
+++ b/test/recv_msg.js
@@ -23,68 +23,57 @@
 module.exports  = recv_msg
 
 function recv_msg(t){
-  t.plan(9)
+  t.plan(3)
 
   const str = 'recv succeeds for'
   const url = 'tcp://127.0.0.1'
   const {
-    bus_open,
     pair0_open,
     pair1_open,
+    push_open,
     pull_open,
-    rep_open,
-    req_open,
-    respondent_open,
-    sub_open,
-    surveyor_open,
     dial,
+    listen,
+    send_msg,
     recv_msg,
+    close,
   } = require('..')
 
   const message = Buffer.from('hello from sender');
 
-  // bus
-  const bus = bus_open()
-  dial(bus, `${url}:7777`)
-  t.is(recv_msg(bus, message), 0, `${str} bus`)
+  // pair0 - two sockets connected
+  const pair0_a = pair0_open()
+  const pair0_b = pair0_open()
+  listen(pair0_a, `${url}:9878`)
+  dial(pair0_b, `${url}:9878`)
+  send_msg(pair0_b, message)
+  const recv_pair0 = recv_msg(pair0_a)
+  t.is(recv_pair0.toString(), message.toString(), `${str} pair0`)
+  close(pair0_a)
+  close(pair0_b)
 
-  // pair0
-  const pair0 = pair0_open()
-  dial(pair0, `${url}:7778`)
-  t.is(recv_msg(pair0, message), 0, `${str} pair0`)
+  // pair1 - two sockets connected
+  const pair1_a = pair1_open()
+  const pair1_b = pair1_open()
+  listen(pair1_a, `${url}:9879`)
+  dial(pair1_b, `${url}:9879`)
+  send_msg(pair1_b, message)
+  const recv_pair1 = recv_msg(pair1_a)
+  t.is(recv_pair1.toString(), message.toString(), `${str} pair1`)
+  close(pair1_a)
+  close(pair1_b)
 
-  // pair1
-  const pair1 = pair1_open()
-  dial(pair1, `${url}:7779`)
-  t.is(recv_msg(pair1, message), 0, `${str} pair1`)
-
-  // pull
+  // push/pull
+  const push = push_open()
   const pull = pull_open()
-  dial(pull, `${url}:7781`)
-  t.is(recv_msg(pull, message), 0, `${str} pull`)
+  listen(pull, `${url}:9882`)
+  dial(push, `${url}:9882`)
+  send_msg(push, message)
+  const recv_pull = recv_msg(pull)
+  t.is(recv_pull.toString(), message.toString(), `${str} pull`)
+  close(push)
+  close(pull)
 
-  // rep
-  const rep = rep_open()
-  dial(rep, `${url}:7783`)
-  t.is(recv_msg(rep, message), 0, `${str} rep`)
-
-  // req
-  const req = req_open()
-  dial(req, `${url}:7784`)
-  t.is(recv_msg(req, message), 0, `${str} req`)
-
-  // respondent
-  const respondent = respondent_open()
-  dial(respondent, `${url}:7785`)
-  t.is(recv_msg(respondent, message), 0, `${str} respondent`)
-
-  // sub
-  const sub = sub_open()
-  dial(sub, `${url}:7786`)
-  t.is(recv_msg(sub, message), 0, `${str} sub`)
-
-  // surveyor
-  const surveyor = surveyor_open()
-  dial(surveyor, `${url}:7787`)
-  t.is(recv_msg(surveyor, message), 0, `${str} surveyor`)
+  // Note: pub/sub requires delay for subscription to propagate
+  // Note: req/rep/surveyor/respondent require proper request-reply exchange
 }

--- a/test/send_msg.js
+++ b/test/send_msg.js
@@ -23,7 +23,7 @@
 module.exports  = send_msg
 
 function send_msg(t){
-  t.plan(9)
+  t.plan(5)
 
   const str = 'send succeeds for'
   const url = 'tcp://127.0.0.1'
@@ -33,58 +33,51 @@ function send_msg(t){
     pair1_open,
     pub_open,
     push_open,
-    rep_open,
-    req_open,
-    respondent_open,
-    surveyor_open,
+    pull_open,
     dial,
+    listen,
     send_msg,
+    close,
   } = require('..')
 
   const message = Buffer.from('hello from sender');
 
   // bus
   const bus = bus_open()
-  dial(bus, `${url}:7777`)
+  listen(bus, `${url}:8877`)
+  dial(bus, `${url}:8877`)
   t.is(send_msg(bus, message), 0, `${str} bus`)
+  close(bus)
 
   // pair0
   const pair0 = pair0_open()
-  dial(pair0, `${url}:7778`)
+  listen(pair0, `${url}:8878`)
+  dial(pair0, `${url}:8878`)
   t.is(send_msg(pair0, message), 0, `${str} pair0`)
+  close(pair0)
 
   // pair1
   const pair1 = pair1_open()
-  dial(pair1, `${url}:7779`)
+  listen(pair1, `${url}:8879`)
+  dial(pair1, `${url}:8879`)
   t.is(send_msg(pair1, message), 0, `${str} pair1`)
+  close(pair1)
 
   // pub
   const pub = pub_open()
-  dial(pub, `${url}:7780`)
+  dial(pub, `${url}:8880`)
   t.is(send_msg(pub, message), 0, `${str} pub`)
+  close(pub)
 
-  // push
+  // push/pull
   const push = push_open()
-  dial(push, `${url}:7782`)
+  const pull = pull_open()
+  listen(pull, `${url}:8882`)
+  dial(push, `${url}:8882`)
   t.is(send_msg(push, message), 0, `${str} push`)
+  close(push)
+  close(pull)
 
-  // rep
-  const rep = rep_open()
-  dial(rep, `${url}:7783`)
-  t.is(send_msg(rep, message), 0, `${str} rep`)
-
-  // req
-  const req = req_open()
-  dial(req, `${url}:7784`)
-  t.is(send_msg(req, message), 0, `${str} req`)
-
-  // respondent
-  const respondent = respondent_open()
-  dial(respondent, `${url}:7785`)
-  t.is(send_msg(respondent, message), 0, `${str} respondent`)
-
-  // surveyor
-  const surveyor = surveyor_open()
-  dial(surveyor, `${url}:7787`)
-  t.is(send_msg(surveyor, message), 0, `${str} surveyor`)
+  // Note: req/rep/surveyor/respondent require proper request-reply exchange
+  // and cannot be tested for send without receiving first (or vice versa)
 }

--- a/test/send_msg.js
+++ b/test/send_msg.js
@@ -1,0 +1,90 @@
+/*
+
+  Copyright (c) 2019 Shiddeshwaran S <shiddeshwaran@gmail.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom
+  the Software is furnished to do so, subject to the following conditions:
+  The above copyright notice and this permission notice shall be included
+  in all copies or substantial portions of the Software.
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+
+*/
+
+module.exports  = send_msg
+
+function send_msg(t){
+  t.plan(9)
+
+  const str = 'send succeeds for'
+  const url = 'tcp://127.0.0.1'
+  const {
+    bus_open,
+    pair0_open,
+    pair1_open,
+    pub_open,
+    push_open,
+    rep_open,
+    req_open,
+    respondent_open,
+    surveyor_open,
+    dial,
+    send_msg,
+  } = require('..')
+
+  const message = Buffer.from('hello from sender');
+
+  // bus
+  const bus = bus_open()
+  dial(bus, `${url}:7777`)
+  t.is(send_msg(bus, message), 0, `${str} bus`)
+
+  // pair0
+  const pair0 = pair0_open()
+  dial(pair0, `${url}:7778`)
+  t.is(send_msg(pair0, message), 0, `${str} pair0`)
+
+  // pair1
+  const pair1 = pair1_open()
+  dial(pair1, `${url}:7779`)
+  t.is(send_msg(pair1, message), 0, `${str} pair1`)
+
+  // pub
+  const pub = pub_open()
+  dial(pub, `${url}:7780`)
+  t.is(send_msg(pub, message), 0, `${str} pub`)
+
+  // push
+  const push = push_open()
+  dial(push, `${url}:7782`)
+  t.is(send_msg(push, message), 0, `${str} push`)
+
+  // rep
+  const rep = rep_open()
+  dial(rep, `${url}:7783`)
+  t.is(send_msg(rep, message), 0, `${str} rep`)
+
+  // req
+  const req = req_open()
+  dial(req, `${url}:7784`)
+  t.is(send_msg(req, message), 0, `${str} req`)
+
+  // respondent
+  const respondent = respondent_open()
+  dial(respondent, `${url}:7785`)
+  t.is(send_msg(respondent, message), 0, `${str} respondent`)
+
+  // surveyor
+  const surveyor = surveyor_open()
+  dial(surveyor, `${url}:7787`)
+  t.is(send_msg(surveyor, message), 0, `${str} surveyor`)
+}


### PR DESCRIPTION
### Summary
This PR adds support for nng 2.x.x and the `send_msg` and `recv_msg` APIs with comprehensive test coverage.

### Changes

**nng 2.x Compatibility**
- Updated `binding.cc` to support nng 2.x API changes
- Uses conditional compilation (`#if NNG_MAJOR_VERSION >= 2`) for backward compatibility
- Updated `compile` script to get the nng branch from env variable `NNG_BRANCH` and use branch `stable` if not set.

**NNG API Support**
- Added `send_msg(socket, buffer)` - Send a message buffer over a socket
- Added `recv_msg(socket)` - Receive a message and return as a Buffer

**Test Suite**
- Added `test/send_msg.js` - Tests send functionality for bus, pair0, pair1, pub, and push sockets
- Added `test/recv_msg.js` - Tests receive functionality for pair0, pair1, and pull sockets
- Tests properly set up connected socket pairs (listen + dial) before send/recv

### Files Changed
| File | Changes |
|------|---------|
| `binding.cc` | Refactored for nng 2.x, added send/recv API support |
| `compile` | Updated build script |
| `test/send_msg.js` | New test file |
| `test/recv_msg.js` | New test file |
| `test/index.js` | Added new tests to test runner |
| `.gitignore` | Minor update |

### Testing
```bash
$ npm test
#....
  total:     55
  passing:   55
  duration:  44ms

  All tests pass!